### PR TITLE
normalize_css: strip units for dimensions with a value of 0 (0px -> 0)

### DIFF
--- a/htmlcompare/compare_css.py
+++ b/htmlcompare/compare_css.py
@@ -7,7 +7,7 @@ from operator import attrgetter
 
 try:
     import tinycss2
-    from tinycss2.ast import Declaration
+    from tinycss2.ast import Declaration, NumberToken
 
     has_tinycss = True
 except ImportError:
@@ -31,6 +31,9 @@ def compare_css(expected_css, actual_css):
     return _e_css_str == _a_css_str
 
 
+def is_dimension(token):
+    return (token.type == 'dimension')
+
 def is_whitespace(token):
     return (token.type == 'whitespace')
 
@@ -42,11 +45,20 @@ def _strip_whitespace(all_tokens):
         tokens.append(token)
     return tokens
 
+def _strip_zero_units(all_tokens):
+    tokens = []
+    for token in all_tokens:
+        if is_dimension(token) and token.int_value == 0:
+            token = NumberToken(token.source_line, token.source_column, token.value, token.int_value, token.representation)
+        tokens.append(token)
+    return tokens
+
 def normalize_css(css_declaration_str):
     _decls = []
     for decl in tinycss2.parse_declaration_list(css_declaration_str, skip_comments=True, skip_whitespace=True):
         assert (decl.type == 'declaration'), decl
         tokens = _strip_whitespace(decl.value)
+        tokens = _strip_zero_units(tokens)
         _decl = Declaration(
             line       = decl.source_line,
             column     = decl.source_column,


### PR DESCRIPTION
I was running into an issue when comparing HTML parsed by premailer where units are automatically removed. Functionally, there is no difference in CSS between 0px and 0; so I don't think we should flag these as differences. This could possibly be adjustable via a setting.